### PR TITLE
Compatibility with eXist 3.1.0+ (incompat. w/ 2.2)

### DIFF
--- a/modules/edit/edit.xq
+++ b/modules/edit/edit.xq
@@ -45,7 +45,7 @@ declare function functx:repeat-string($stringToRepeat as xs:string?, $count as x
    string-join((for $i in 1 to $count return $stringToRepeat), '')
  };
  
-declare function local:create-new-record($id as xs:string, $type-request as xs:string, $target-collection as xs:string) as empty() {
+declare function local:create-new-record($id as xs:string, $type-request as xs:string, $target-collection as xs:string) as empty-sequence() {
     (:Copy the template and store it with the ID as file name.:)
     (:First, get the right template, based on the type-request and the presence or absence of transliteration.:)
     let $transliterationOfResource := request:get-parameter("transliterationOfResource", '')


### PR DESCRIPTION
Once https://github.com/eXist-db/exist/pull/1319 is merged and released (not in eXist 3.1.0, but likely the following release), the use of `empty()` as a node test is disallowed in favor of `empty-sequence()` (see [XQuery 1.0 spec](https://www.w3.org/TR/xquery/#id-sequencetype-syntax)) where this is defined).

Tamboti's `expath-pkg.xml` seems to imply it is intended for eXist 2.2, so I would not recommend merging this PR if/until Tamboti moves to 3.0.